### PR TITLE
Babel require.default

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -17,6 +17,7 @@
     "transform-runtime",
     "transform-object-rest-spread",
     "transform-decorators-legacy",
+    "add-module-exports",
     [
       "babel-plugin-transform-builtin-extend",
       {

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ opts = {
 server.js:
 
 ```js
+import net from 'net'
+import SocketPacket from 'socket-packet'
+/* OR */
 const net = require('net')
 const SocketPacket = require('socket-packet')
 
@@ -194,6 +197,9 @@ server.listen(port, host, () => {
 client.js:
 
 ```js
+import net from 'net'
+import SocketPacket from 'socket-packet'
+/* OR */
 const net = require('net')
 const SocketPacket = require('socket-packet')
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,95 @@ opts = {
 }
 ```
 
+## Example
+
+server.js:
+
+```js
+const net = require('net')
+const SocketPacket = require('socket-packet')
+
+const port = process.env.PORT || 8080
+const host = process.env.HOST || 'localhost'
+
+const server = net.createServer(socket => {
+  console.log('Client connected')
+  SocketPacket.bind(socket)
+
+  socket.on('packet', packet => {
+    switch (packet) {
+      case 'ping': 
+        console.log('ping received')
+
+        setTimeout(() => {
+          socket.send('pong', () => {
+            console.log('pong sent')
+          })
+        }, 500)
+        break
+      default:
+        console.log('Unhandled packet received: ', packet)    
+    }
+  })
+
+  socket.on('error', err => {
+    console.log('Error:', err)
+  })
+
+  socket.on('end', () => {
+    console.log('Client ended')
+  })
+
+  socket.on('close', hadError => {
+    console.log('Client disconnected')
+  })
+})
+
+server.listen(port, host, () => {
+  console.log(`Server started on ${server.address().address}:${server.address().port}`)
+})
+```
+
+client.js:
+
+```js
+const net = require('net')
+const SocketPacket = require('socket-packet')
+
+const port = process.env.PORT || 8080
+const host = process.env.HOST || '0.0.0.0'
+
+const client = net.createConnection({ port, host }, () => {
+  console.log('connection established')
+  SocketPacket.bind(client)
+})
+
+client.on('packet', packet => {
+  switch (packet) {
+    case 'pong':
+      console.log('pong received')
+      break
+    default:
+      console.log('Unhandled packet received: ', packet)
+  }
+})
+
+client.on('close', hasError => {
+  console.log(`Connection closed with error = ${!!hasError}`)
+  clearInterval(interval)
+})
+
+client.on('error', err => {
+  console.log(err)
+})
+
+const interval = setInterval(() => {
+  client.send('ping', () => {
+    console.log('ping sent')
+  })
+}, 2000)
+```
+
 ## Dev setup
 
 You will need to get/generate your Codacy account api token (not project token) and your username ready for this:

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ const net = require('net')
 const SocketPacket = require('socket-packet')
 
 const port = process.env.PORT || 8080
-const host = process.env.HOST || '0.0.0.0'
+const host = process.env.HOST || 'localhost'
 
 const client = net.createConnection({ port, host }, () => {
   console.log('connection established')

--- a/package-lock.json
+++ b/package-lock.json
@@ -818,6 +818,12 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-add-module-exports": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz",
+      "integrity": "sha1-mumh9KjcZ/DN7E9K7aHkOl/2XiU=",
+      "dev": true
+    },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     }
   },
   "pre-commit": [
-    "tc"
+    "report"
   ],
   "standard": {
     "env": [

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
     "babel-loader": "^7.1.4",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-istanbul": "^4.1.6",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ class SocketPacket {
 
     packets.forEach(packet => {
       if (packet.indexOf(this._startsWith) !== 0 || packet.indexOf(this._endsWith) !== packet.length - this._endLen) {
-        this._socket.emit('error', `Malformed packet received: ${packet}`)
+        this._socket.emit('error', new Error(`Malformed packet received: ${packet}`))
         return
       }
 
@@ -56,7 +56,7 @@ class SocketPacket {
         this._socket.emit('packet', parsedPacket)
       } catch (err) {
         this.log('error', `Packet parse failed!: ${strippedPacket}`)
-        this._socket.emit('error', `Parsing of inbound packet errored: ${err.message}`)
+        this._socket.emit('error', new Error(`Parsing of inbound packet errored: ${err.message}`))
       }
     })
   }

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -202,7 +202,8 @@ describe('SocketPacket', () => {
           client.end()
           server.close()
 
-          assert.equal(err, 'Parsing of inbound packet errored: Unexpected token p in JSON at position 0')
+          assert(err instanceof Error, 'Expected err to be an instance of an error, but wasn\'t')
+          assert.equal(err.message, 'Parsing of inbound packet errored: Unexpected token p in JSON at position 0')
 
           done()
         })

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -88,7 +88,8 @@ describe.only('SocketPacket', () => {
           done()
         })
         socket.on('error', err => {
-          assert.equal(err, 'Malformed packet received: 123')
+          assert(err instanceof Error, 'Expected err to be an instance of an error, but wasn\'t')
+          assert.equal(err.message, 'Malformed packet received: 123')
           errorHandled = true
         })
         socketPacket.onData(data)
@@ -103,7 +104,8 @@ describe.only('SocketPacket', () => {
         })
         socket.on('error', err => {
           errorHandled = true
-          assert.equal(err, 'Malformed packet received: 123')
+          assert(err instanceof Error, 'Expected err to be an instance of an error, but wasn\'t')
+          assert.equal(err.message, 'Malformed packet received: 123')
         })
         socket.emit('data', data)
       })


### PR DESCRIPTION
Babel was transpiling code so that when using 'require('socket-packet)', u'd have to use 'require('socket-packet')'.default(), changed this to just 'require('socket-packet')'